### PR TITLE
Add persistent storage and restoration for paired MT5 trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,19 @@ Notes
 - Only trades created by this app are shown in the table.
 - Profit values refresh periodically; closed pairs are removed from the table.
 
+Persistence
+-----------
+
+- The UI persists its session data (paired trades, trade counter, and the last used terminal
+  paths) to ``%USERPROFILE%\.swap_gainer\state.json`` on Windows (or ``~/.swap_gainer/state.json``
+  on other platforms).
+- State is saved after every trade create/close event and again during shutdown so that the app
+  can restore open positions on the next launch.
+- When the application starts it automatically reloads the saved file, reconnects to the recorded
+  terminals, validates that the saved tickets are still open, and repopulates the table for any
+  trades that remain active. Closed or invalid entries are discarded.
+- If the JSON file becomes corrupted or you need to reset the saved state, exit the application,
+  delete ``state.json`` (or move it aside), and restart the UI. The app will report any load/save
+  errors in a pop-up dialog so operators are aware of persistence issues.
+
 


### PR DESCRIPTION
## Summary
- add a JSON-backed persistence layer for paired trades, the trade counter, and terminal paths, writing updates after trade lifecycle events and shutdown
- reload saved state on startup by reconnecting to the recorded terminals, validating tickets remain open, and repopulating the UI while dropping stale entries
- document the persistence workflow and recovery instructions for operators in the README

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c8bdeb6483259e081e3314103b88