### PR TITLE
Add structured automation config file and schedule overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Usage
 4. Click BUY (Simultaneous) or SELL (Simultaneous).
 5. Manage pairs in the table; use Close on a row to close both trades.
 
+Configuration
+-------------
+
+- Automation settings now live in `automation_config.json`. Each section contains an
+  ordered list of trade "threads" you can customise with entry windows, symbols,
+  directions, lot sizes, spread limits, and weekdays. The UI reads this file at
+  startup and displays a structured overview of every configured schedule along
+  with the next eligible run time.
+- Runtime state (e.g. last time a schedule executed) is stored separately in
+  `automation_state.json`. Editing the configuration file will not reset history.
+
 Notes
 
 - The app resolves .lnk shortcuts to the target terminal automatically (requires pywin32).

--- a/automation_config.json
+++ b/automation_config.json
@@ -1,0 +1,91 @@
+{
+  "timezone": "UTC",
+  "risk": {
+    "drawdown_enabled": false,
+    "drawdown_stop": 5.0
+  },
+  "primary_threads": [
+    {
+      "thread_id": "primary-1",
+      "name": "Primary Set 1",
+      "enabled": true,
+      "entry_start": "09:00",
+      "entry_end": "11:00",
+      "symbol1": "EURUSD",
+      "symbol2": "GBPUSD",
+      "lot1": 0.1,
+      "lot2": 0.1,
+      "direction": "buy_sell",
+      "max_entry_spread": 1.5,
+      "close_after_minutes": 180,
+      "max_exit_spread": 1.0,
+      "weekdays": [0, 1, 2, 3, 4]
+    },
+    {
+      "thread_id": "primary-2",
+      "name": "Primary Set 2",
+      "enabled": false,
+      "entry_start": "13:00",
+      "entry_end": "15:00",
+      "symbol1": "USDJPY",
+      "symbol2": "AUDUSD",
+      "lot1": 0.05,
+      "lot2": 0.05,
+      "direction": "sell_buy",
+      "max_entry_spread": 1.2,
+      "close_after_minutes": 120,
+      "max_exit_spread": 0.8,
+      "weekdays": [0, 1, 2, 3, 4]
+    }
+  ],
+  "wednesday_threads": [
+    {
+      "thread_id": "wednesday-1",
+      "name": "Wednesday Set 1",
+      "enabled": true,
+      "entry_start": "20:00",
+      "entry_end": "23:00",
+      "symbol1": "NZDUSD",
+      "symbol2": "AUDNZD",
+      "lot1": 0.08,
+      "lot2": 0.08,
+      "direction": "buy_sell",
+      "max_entry_spread": 1.6,
+      "close_after_minutes": 240,
+      "max_exit_spread": 1.2,
+      "weekdays": [2]
+    },
+    {
+      "thread_id": "wednesday-2",
+      "name": "Wednesday Set 2",
+      "enabled": false,
+      "entry_start": "00:30",
+      "entry_end": "02:00",
+      "symbol1": "EURCHF",
+      "symbol2": "GBPCHF",
+      "lot1": 0.05,
+      "lot2": 0.05,
+      "direction": "sell_sell",
+      "max_entry_spread": 1.0,
+      "close_after_minutes": 90,
+      "max_exit_spread": 0.7,
+      "weekdays": [2]
+    },
+    {
+      "thread_id": "wednesday-3",
+      "name": "Wednesday Set 3",
+      "enabled": false,
+      "entry_start": "05:00",
+      "entry_end": "07:00",
+      "symbol1": "USDCAD",
+      "symbol2": "CADJPY",
+      "lot1": 0.06,
+      "lot2": 0.06,
+      "direction": "buy_buy",
+      "max_entry_spread": 1.4,
+      "close_after_minutes": 180,
+      "max_exit_spread": 1.0,
+      "weekdays": [2]
+    }
+  ]
+}

--- a/persistence.py
+++ b/persistence.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import threading
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 from automation import AppConfig, AutomationState
 
@@ -11,37 +11,106 @@ from automation import AppConfig, AutomationState
 class Persistence:
     """Simple JSON-backed persistence for automation settings/state."""
 
-    def __init__(self, path: Path) -> None:
-        self._path = path
+    def __init__(self, state_path: Path, config_path: Optional[Path] = None) -> None:
+        self._state_path = state_path
+        self._config_path = config_path or state_path.with_name("automation_config.json")
         self._lock = threading.Lock()
         self._config = AppConfig()
         self._state = AutomationState()
         self._load()
+        self._ensure_files_exist()
 
     def _load(self) -> None:
-        if not self._path.exists():
-            return
+        combined_data: Optional[object] = None
+        if self._state_path.exists():
+            try:
+                with self._state_path.open("r", encoding="utf-8") as fh:
+                    combined_data = json.load(fh)
+            except Exception:
+                combined_data = None
+
+        config_loaded = self._load_config()
+        state_loaded = self._load_state(combined_data)
+
+        if not config_loaded and isinstance(combined_data, dict):
+            cfg = combined_data.get("config")
+            if cfg:
+                try:
+                    self._config = AppConfig.from_dict(cfg)
+                    config_loaded = True
+                except Exception:
+                    pass
+
+        if not config_loaded:
+            self._config = AppConfig()
+        if not state_loaded:
+            state_loaded = self._load_state()
+            if not state_loaded:
+                self._state = AutomationState()
+
+    def _load_config(self) -> bool:
+        if not self._config_path.exists():
+            return False
         try:
-            with self._path.open("r", encoding="utf-8") as fh:
+            with self._config_path.open("r", encoding="utf-8") as fh:
                 data = json.load(fh)
         except Exception:
-            return
-        cfg = data.get("config") if isinstance(data, dict) else None
-        st = data.get("state") if isinstance(data, dict) else None
-        if cfg:
-            self._config = AppConfig.from_dict(cfg)
-        if st:
-            self._state = AutomationState.from_dict(st)
+            return False
+        if isinstance(data, dict):
+            if "config" in data:
+                cfg_data = data.get("config")
+            else:
+                cfg_data = data
+            try:
+                self._config = AppConfig.from_dict(cfg_data)
+            except Exception:
+                return False
+            return True
+        return False
 
-    def _write(self) -> None:
-        payload: Dict[str, object] = {
-            "config": self._config.to_dict(),
-            "state": self._state.to_dict(),
-        }
-        tmp_path = self._path.with_suffix(".tmp")
+    def _load_state(self, data: Optional[object] = None) -> bool:
+        if data is None:
+            if not self._state_path.exists():
+                return False
+            try:
+                with self._state_path.open("r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+            except Exception:
+                return False
+        payload = None
+        if isinstance(data, dict) and "state" in data:
+            payload = data.get("state")
+        elif isinstance(data, dict):
+            payload = data
+        if isinstance(payload, dict):
+            try:
+                self._state = AutomationState.from_dict(payload)
+            except Exception:
+                return False
+            return True
+        return False
+
+    def _ensure_files_exist(self) -> None:
+        if not self._config_path.exists():
+            self._write_config()
+        if not self._state_path.exists():
+            self._write_state()
+
+    def _write_config(self) -> None:
+        payload: Dict[str, object] = self._config.to_dict()
+        self._config_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._config_path.with_suffix(".tmp")
         with tmp_path.open("w", encoding="utf-8") as fh:
             json.dump(payload, fh, indent=2)
-        tmp_path.replace(self._path)
+        tmp_path.replace(self._config_path)
+
+    def _write_state(self) -> None:
+        payload: Dict[str, object] = {"state": self._state.to_dict()}
+        self._state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._state_path.with_suffix(".tmp")
+        with tmp_path.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+        tmp_path.replace(self._state_path)
 
     def get_config(self) -> AppConfig:
         with self._lock:
@@ -50,7 +119,7 @@ class Persistence:
     def save_config(self, config: AppConfig) -> None:
         with self._lock:
             self._config = config
-            self._write()
+            self._write_config()
 
     def get_state(self) -> AutomationState:
         with self._lock:
@@ -59,5 +128,5 @@ class Persistence:
     def save_state(self, state: AutomationState) -> None:
         with self._lock:
             self._state = state
-            self._write()
+            self._write_state()
 


### PR DESCRIPTION
## Summary
- add an `automation_config.json` file that holds the editable automation schedule defaults
- update the persistence layer to read/write the new config file while keeping the old state format working
- enhance the automation UI with a schedule overview table and document the new configuration workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8cd7e02748325a8daaae3b1a50456