### PR TITLE
Prevent scheduled trades from closing before hold period elapses

### DIFF
--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -66,6 +66,16 @@ class AutomationLogicTests(unittest.TestCase):
         spreads = {"EURUSD": 0.4, "USDJPY": 0.3}
         self.assertEqual(trades_due_for_close([trade], self.now, spreads), ["T2"])
 
+    def test_trade_waits_for_hold_time_before_spread_exit(self) -> None:
+        opened = self.now - timedelta(minutes=10)
+        trade = TrackedTrade("T3", opened, ("EURUSD", "USDJPY"), 60, 0.5)
+        spreads = {"EURUSD": 0.4, "USDJPY": 0.3}
+        # Still within hold period, should not close
+        self.assertEqual(trades_due_for_close([trade], self.now, spreads), [])
+
+        later = self.now + timedelta(minutes=60)
+        self.assertEqual(trades_due_for_close([trade], later, spreads), ["T3"])
+
     def test_drawdown_detection(self) -> None:
         risk = RiskConfig(drawdown_enabled=True, drawdown_stop=5.0)
         accounts = [{"balance": 1000, "equity": 930}, {"balance": 2000, "equity": 1980}]


### PR DESCRIPTION
## Summary
- prevent the automation from closing trades before the configured hold time finishes
- require exit spread conditions to be met after the hold period instead of immediately
- add regression coverage so trades wait for the hold window before spread-based exits

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbc60fd7c483259679ed14e7138be6