### PR TITLE
Persist and restore active trades

### DIFF
--- a/automation.py
+++ b/automation.py
@@ -266,23 +266,35 @@ class AppConfig:
 class AutomationState:
     last_runs: Dict[str, str] = field(default_factory=dict)
     trade_history: List[Dict[str, Any]] = field(default_factory=list)
+    active_trades: List[Dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, object]:
-        return {"last_runs": dict(self.last_runs), "trade_history": [dict(entry) for entry in self.trade_history]}
+        return {
+            "last_runs": dict(self.last_runs),
+            "trade_history": [dict(entry) for entry in self.trade_history],
+            "active_trades": [dict(entry) for entry in self.active_trades],
+        }
 
     @classmethod
     def from_dict(cls, data: Optional[Dict[str, object]]) -> "AutomationState":
         data = data or {}
         lr = data.get("last_runs") or {}
         raw_history = data.get("trade_history") or []
+        raw_active = data.get("active_trades") or []
         history: List[Dict[str, Any]] = []
         if isinstance(raw_history, list):
             for item in raw_history:
                 if isinstance(item, dict):
                     history.append({str(k): item[k] for k in item.keys()})
+        active_trades: List[Dict[str, Any]] = []
+        if isinstance(raw_active, list):
+            for item in raw_active:
+                if isinstance(item, dict):
+                    active_trades.append({str(k): item[k] for k in item.keys()})
         return cls(
             last_runs={str(k): str(v) for k, v in lr.items()},
             trade_history=history,
+            active_trades=active_trades,
         )
 
 

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -32,6 +32,28 @@ class AutomationLogicTests(unittest.TestCase):
         self.assertIsNone(parse_time_string("bad"))
         self.assertIsNone(parse_time_string(""))
 
+    def test_state_active_trades_round_trip(self) -> None:
+        state = AutomationState(
+            last_runs={"primary-1": "2024-05-06"},
+            trade_history=[{"trade_id": "T00001"}],
+            active_trades=[
+                {
+                    "trade_id": "T00002",
+                    "account1": {"symbol": "EURUSD", "lot": 0.01},
+                    "account2": {"symbol": "USDJPY", "lot": 0.02},
+                }
+            ],
+        )
+
+        data = state.to_dict()
+        restored = AutomationState.from_dict(data)
+
+        self.assertEqual(restored.active_trades, state.active_trades)
+
+    def test_state_active_trades_missing_defaults_to_empty(self) -> None:
+        restored = AutomationState.from_dict({"last_runs": {}, "trade_history": []})
+        self.assertEqual(restored.active_trades, [])
+
     def test_schedule_triggers_once_per_day(self) -> None:
         schedule = ThreadSchedule(
             thread_id="primary-1",


### PR DESCRIPTION
## Summary
- extend `AutomationState` persistence to include active trades information
- restore and display active trades on app startup while snapshotting current state before saves
- add regression tests covering active trade serialization defaults

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbd6dd4d0c8325b16d2a6de4a23987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Active trades are now persisted and restored between sessions.
  - UI repopulates open trades on launch and resumes the trade counter from existing data.
- Improvements
  - Trade entries are normalized and displayed consistently with updated metrics.
  - State is saved more reliably after opening, updating, or closing trades.
  - Automation keeps UI and stored state in sync as changes occur.
- Tests
  - Added tests verifying active trades are correctly serialized, deserialized, and defaulted when missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->