### PR TITLE
Add net PnL exit logic with configuration and tracking

### DIFF
--- a/automation_config.json
+++ b/automation_config.json
@@ -4,6 +4,12 @@
     "drawdown_enabled": false,
     "drawdown_stop": 5.0
   },
+  "exit": {
+    "close_logic_mode": "spread",
+    "net_pnl_threshold": 0.0,
+    "close_start_minutes": 60,
+    "close_stop_minutes": 90
+  },
   "primary_threads": [
     {
       "thread_id": "primary-1",

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -10,6 +10,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from automation import (
     AppConfig,
     AutomationState,
+    ExitConfig,
     RiskConfig,
     ThreadSchedule,
     TrackedTrade,
@@ -53,6 +54,28 @@ class AutomationLogicTests(unittest.TestCase):
     def test_state_active_trades_missing_defaults_to_empty(self) -> None:
         restored = AutomationState.from_dict({"last_runs": {}, "trade_history": []})
         self.assertEqual(restored.active_trades, [])
+
+    def test_exit_config_defaults(self) -> None:
+        config = AppConfig.from_dict({})
+        self.assertEqual(config.exit.close_logic_mode, "spread")
+        self.assertEqual(config.exit.net_pnl_threshold, 0.0)
+        self.assertEqual(config.exit.close_start_minutes, 60)
+        self.assertEqual(config.exit.close_stop_minutes, 90)
+
+    def test_exit_config_custom_values(self) -> None:
+        data = {
+            "exit": {
+                "close_logic_mode": "net_pnl_threshold",
+                "net_pnl_threshold": 12.5,
+                "close_start_minutes": 45,
+                "close_stop_minutes": 90,
+            }
+        }
+        config = AppConfig.from_dict(data)
+        self.assertEqual(config.exit.close_logic_mode, "net_pnl_threshold")
+        self.assertEqual(config.exit.net_pnl_threshold, 12.5)
+        self.assertEqual(config.exit.close_start_minutes, 45)
+        self.assertEqual(config.exit.close_stop_minutes, 90)
 
     def test_schedule_triggers_once_per_day(self) -> None:
         schedule = ThreadSchedule(


### PR DESCRIPTION
## Summary
- add an ExitConfig to automation settings and wire the GUI config summary to show the new exit strategy controls
- store exit strategy metadata on active trades and include it when exporting history and CSVs
- extend automation to support a net PnL threshold exit window with forced close after the window and retry tracking

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dc1758ee588325a3f9db46c64fc33e