### PR TITLE
Update default XM terminal path

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ from automation import (
 from persistence import Persistence
 
 
-DEFAULT_TERMINAL_1 = r"C:\Users\Public\Desktop\XM Global MT5.lnk"
+DEFAULT_TERMINAL_1 = r"C:\Users\Public\Desktop\XM MT5.lnk"
 DEFAULT_TERMINAL_2 = r"C:\Users\Public\Desktop\Tickmill MT5 Terminal.lnk"
 
 


### PR DESCRIPTION
## Summary
- update the default XM terminal shortcut path to the new location

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1d9cf24c8325814ad0445ad734b8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default terminal shortcut to “XM MT5” (replacing “XM Global MT5”) so the app opens the correct terminal with default settings.
  * Prevents launch issues on newer installations where the old shortcut no longer exists.
  * Secondary default terminal remains unchanged; users with custom paths are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->