### PR TITLE
Add configurable auto-close options and improve trade tracking

### DIFF
--- a/automation_config.json
+++ b/automation_config.json
@@ -19,6 +19,10 @@
       "max_entry_spread": 1.5,
       "close_after_minutes": 180,
       "max_exit_spread": 1.0,
+      "close_condition": "spread",
+      "min_combined_profit": 0.0,
+      "close_window_start": "",
+      "close_window_end": "",
       "weekdays": [0, 1, 2, 3, 4]
     },
     {
@@ -35,6 +39,10 @@
       "max_entry_spread": 1.2,
       "close_after_minutes": 120,
       "max_exit_spread": 0.8,
+      "close_condition": "profit",
+      "min_combined_profit": 12.5,
+      "close_window_start": "12:30",
+      "close_window_end": "17:00",
       "weekdays": [0, 1, 2, 3, 4]
     }
   ],
@@ -53,6 +61,10 @@
       "max_entry_spread": 1.6,
       "close_after_minutes": 240,
       "max_exit_spread": 1.2,
+      "close_condition": "spread_and_profit",
+      "min_combined_profit": 15.0,
+      "close_window_start": "20:30",
+      "close_window_end": "23:30",
       "weekdays": [2]
     },
     {
@@ -69,6 +81,10 @@
       "max_entry_spread": 1.0,
       "close_after_minutes": 90,
       "max_exit_spread": 0.7,
+      "close_condition": "spread",
+      "min_combined_profit": 0.0,
+      "close_window_start": "",
+      "close_window_end": "",
       "weekdays": [2]
     },
     {
@@ -85,6 +101,10 @@
       "max_entry_spread": 1.4,
       "close_after_minutes": 180,
       "max_exit_spread": 1.0,
+      "close_condition": "profit",
+      "min_combined_profit": 10.0,
+      "close_window_start": "05:30",
+      "close_window_end": "08:00",
       "weekdays": [2]
     }
   ]


### PR DESCRIPTION
## Summary
- extend automation schedule configuration with close-condition, profit target, and close-window controls and persist them in the sample config
- update the desktop UI, automation state handling, and trade history to honour the new close settings and record close reasons
- harden MT5 close execution verification and expand unit tests around auto-closing logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc25559e388325b3d785e56792a7aa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added close rules for trades: spread, profit, or both, with optional time windows.
  - New minimum combined profit threshold for profit-based closing.
  - UI now shows Close Rule in schedules and Close Reason in history.
  - Trade history CSV export includes Close Reason.

- Enhancements
  - Auto-close provides reasoned outcomes and respects configured time windows and profit thresholds.
  - Configuration supports new close rule fields and window settings.
  - More reliable trade closing with post-close verification to confirm positions are actually closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->