### PR TITLE
Force close trades once close window elapses

### DIFF
--- a/automation.py
+++ b/automation.py
@@ -422,12 +422,22 @@ def trades_due_for_close(
 
         start_window = trade.close_window_start
         end_window = trade.close_window_end
-        if (start_window is not None or end_window is not None) and not _time_in_window(
-            now.time(),
-            start_window,
-            end_window,
-        ):
-            continue
+        window_defined = start_window is not None or end_window is not None
+        if window_defined:
+            in_window = _time_in_window(
+                now.time(),
+                start_window,
+                end_window,
+            )
+            if not in_window:
+                if (
+                    start_window is not None
+                    and end_window is not None
+                    and start_window <= end_window
+                    and now.time() > end_window
+                ):
+                    to_close.append((trade.trade_id, "time_window_elapsed"))
+                continue
 
         condition = (trade.close_condition or "spread").lower()
         if condition not in {"spread", "profit", "spread_and_profit"}:

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -204,6 +204,25 @@ class AutomationLogicTests(unittest.TestCase):
             [("T5", "spread")],
         )
 
+    def test_trade_forced_closed_when_window_expires(self) -> None:
+        opened = datetime(2024, 5, 5, 18, 0, tzinfo=timezone.utc)
+        trade = TrackedTrade(
+            "T6",
+            opened,
+            ("EURUSD", "USDJPY"),
+            720,
+            0.2,
+            "profit",
+            8.0,
+            time(1, 0),
+            time(5, 0),
+        )
+        after_window = datetime(2024, 5, 6, 6, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            trades_due_for_close([trade], after_window, {"EURUSD": 5.0}, {"T6": 2.0}),
+            [("T6", "time_window_elapsed")],
+        )
+
     def test_drawdown_detection(self) -> None:
         risk = RiskConfig(drawdown_enabled=True, drawdown_stop=5.0)
         


### PR DESCRIPTION
## Summary
- force trades to close immediately once the configured close window has expired
- add regression test to ensure expired close window triggers a closure even without profit

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68de62101da08325a91371f9b93cf6aa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Trades now respect an optional time window: they are considered for closing only when within the window.
  - When a trade’s closing window has fully elapsed, it can be closed with a clear reason: “time_window_elapsed,” improving transparency.
  - Outside the defined window (before it starts or between days), trades are skipped rather than prematurely closed.

- Tests
  - Added a test ensuring trades past their allowed closing window are correctly flagged and closed with the “time_window_elapsed” reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->