### PR TITLE
Add persistent schedule mode that runs until drawdown

### DIFF
--- a/automation.py
+++ b/automation.py
@@ -23,6 +23,20 @@ def _normalise_close_condition(value: Optional[object]) -> str:
     return "spread"
 
 
+def _coerce_bool(value: Optional[object]) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "n", "off"}:
+            return False
+    return False
+
+
 @dataclass
 class ThreadSchedule:
     thread_id: str
@@ -43,6 +57,7 @@ class ThreadSchedule:
     close_window_start: str = ""
     close_window_end: str = ""
     weekdays: List[int] = field(default_factory=_default_primary_weekdays)
+    keep_open_until_drawdown: bool = False
 
     def to_dict(self) -> Dict[str, object]:
         return {
@@ -64,6 +79,7 @@ class ThreadSchedule:
             "close_window_start": self.close_window_start,
             "close_window_end": self.close_window_end,
             "weekdays": list(self.weekdays),
+            "keep_open_until_drawdown": self.keep_open_until_drawdown,
         }
 
     @staticmethod
@@ -123,6 +139,7 @@ class ThreadSchedule:
             close_window_start=str(data.get("close_window_start") or ""),
             close_window_end=str(data.get("close_window_end") or ""),
             weekdays=wd,
+            keep_open_until_drawdown=_coerce_bool(data.get("keep_open_until_drawdown")),
         )
 
 
@@ -330,6 +347,7 @@ class TrackedTrade:
     min_combined_profit: float = 0.0
     close_window_start: Optional[time] = None
     close_window_end: Optional[time] = None
+    keep_open_until_drawdown: bool = False
 
 
 def parse_time_string(value: str) -> Optional[time]:
@@ -369,6 +387,16 @@ def schedule_should_trigger(
         return False
     if schedule.weekdays and now.weekday() not in schedule.weekdays:
         return False
+    if schedule.keep_open_until_drawdown:
+        active_trades = getattr(state, "active_trades", [])
+        if isinstance(active_trades, list):
+            for entry in active_trades:
+                if not isinstance(entry, dict):
+                    continue
+                tid = str(entry.get("thread_id") or "").strip()
+                if tid and tid == schedule.thread_id:
+                    return False
+
     start_at = parse_time_string(schedule.entry_start)
     end_at = parse_time_string(schedule.entry_end) if schedule.entry_end else None
     if start_at is None and end_at is None:
@@ -398,7 +426,10 @@ def trades_due_for_close(
     close conditions are ``"spread"`` (default behaviour), ``"profit"`` and
     ``"spread_and_profit"``. Trades may optionally define a closing time window
     via ``close_window_start`` / ``close_window_end``; if provided the current
-    timestamp must fall within that window for the trade to be considered.
+    timestamp must fall within that window for the trade to be considered. When
+    ``keep_open_until_drawdown`` is set on a trade the automation will skip all
+    automatic close checks, leaving termination to manual actions or global risk
+    controls such as drawdown stops.
 
     Parameters:
         trades: Tracked trades to evaluate.
@@ -414,6 +445,8 @@ def trades_due_for_close(
 
     to_close: List[Tuple[str, str]] = []
     for trade in trades:
+        if getattr(trade, "keep_open_until_drawdown", False):
+            continue
         min_hold_minutes = max(int(trade.close_after_minutes), 0)
         hold_delta = timedelta(minutes=min_hold_minutes) if min_hold_minutes > 0 else None
 

--- a/automation_config.json
+++ b/automation_config.json
@@ -23,7 +23,8 @@
       "min_combined_profit": 0.0,
       "close_window_start": "",
       "close_window_end": "",
-      "weekdays": [0, 1, 2, 3, 4]
+      "weekdays": [0, 1, 2, 3, 4],
+      "keep_open_until_drawdown": false
     },
     {
       "thread_id": "primary-2",
@@ -43,7 +44,8 @@
       "min_combined_profit": 12.5,
       "close_window_start": "12:30",
       "close_window_end": "17:00",
-      "weekdays": [0, 1, 2, 3, 4]
+      "weekdays": [0, 1, 2, 3, 4],
+      "keep_open_until_drawdown": false
     }
   ],
   "wednesday_threads": [
@@ -65,7 +67,8 @@
       "min_combined_profit": 15.0,
       "close_window_start": "20:30",
       "close_window_end": "23:30",
-      "weekdays": [2]
+      "weekdays": [2],
+      "keep_open_until_drawdown": false
     },
     {
       "thread_id": "wednesday-2",
@@ -85,7 +88,8 @@
       "min_combined_profit": 0.0,
       "close_window_start": "",
       "close_window_end": "",
-      "weekdays": [2]
+      "weekdays": [2],
+      "keep_open_until_drawdown": false
     },
     {
       "thread_id": "wednesday-3",
@@ -105,7 +109,8 @@
       "min_combined_profit": 10.0,
       "close_window_start": "05:30",
       "close_window_end": "08:00",
-      "weekdays": [2]
+      "weekdays": [2],
+      "keep_open_until_drawdown": false
     }
   ]
 }

--- a/main.py
+++ b/main.py
@@ -741,8 +741,11 @@ class App:
             self.config_tree.insert(node, 'end', text='Entry Window', values=(self._format_entry_window(thread),))
             self.config_tree.insert(node, 'end', text='Weekdays', values=(self._format_weekdays(thread.weekdays),))
             self.config_tree.insert(node, 'end', text='Max Entry Spread', values=(self._format_number(thread.max_entry_spread),))
-            close_after = self._hours_from_minutes(thread.close_after_minutes)
-            close_text = f"{close_after} h" if close_after != '0' else 'n/a'
+            if thread.keep_open_until_drawdown:
+                close_text = 'Manual / drawdown'
+            else:
+                close_after = self._hours_from_minutes(thread.close_after_minutes)
+                close_text = f"{close_after} h" if close_after != '0' else 'n/a'
             self.config_tree.insert(node, 'end', text='Close After', values=(close_text,))
             self.config_tree.insert(node, 'end', text='Max Exit Spread', values=(self._format_number(thread.max_exit_spread),))
             self.config_tree.insert(
@@ -920,6 +923,15 @@ class App:
                 "combined_profit": combined_profit,
             },
         )
+
+    def _has_active_trade_for_thread(self, thread_id: Optional[str]) -> bool:
+        if not thread_id:
+            return False
+        with self._trade_lock:
+            for info in self.paired_trades.values():
+                if str(info.get("thread_id") or "") == thread_id:
+                    return True
+        return False
 
     def _snapshot_active_trades(self) -> list[Dict[str, Any]]:
         snapshot: list[Dict[str, Any]] = []
@@ -1264,6 +1276,8 @@ class App:
         return "Any time"
 
     def _format_close_condition(self, schedule: ThreadSchedule) -> str:
+        if schedule.keep_open_until_drawdown:
+            return "Manual close / Drawdown"
         condition = (schedule.close_condition or "spread").lower()
         spread_limit = float(schedule.max_exit_spread or 0.0)
         profit_target = float(schedule.min_combined_profit or 0.0)
@@ -1282,6 +1296,8 @@ class App:
         return spread_text
 
     def _format_close_rule(self, schedule: ThreadSchedule) -> str:
+        if schedule.keep_open_until_drawdown:
+            return "Manual close or drawdown stop"
         parts: list[str] = []
         hold_minutes = max(int(schedule.close_after_minutes or 0), 0)
         if hold_minutes > 0:
@@ -1338,6 +1354,8 @@ class App:
     ) -> Optional[Union[datetime, str]]:
         if not schedule.enabled:
             return None
+        if schedule.keep_open_until_drawdown and self._has_active_trade_for_thread(schedule.thread_id):
+            return "Active (manual/drawdown)"
         start_time = parse_time_string(schedule.entry_start)
         if start_time is None:
             return "Set entry time"
@@ -1418,6 +1436,7 @@ class App:
                 sides[1],
                 schedule_name=schedule.name,
                 schedule_thread_id=schedule.thread_id,
+                keep_open_until_drawdown=schedule.keep_open_until_drawdown,
             )
             self._set_automation_status(
                 f"Scheduled trade executed for {schedule.name} ({schedule.thread_id}).",
@@ -1445,6 +1464,8 @@ class App:
         side2: str,
         schedule_name: Optional[str] = None,
         schedule_thread_id: Optional[str] = None,
+        *,
+        keep_open_until_drawdown: bool = False,
     ) -> str:
         if not (self.connected1 and self.connected2 and self.worker1 and self.worker2):
             raise RuntimeError("Connect both terminals first.")
@@ -1487,6 +1508,7 @@ class App:
             "schedule": schedule_name or "manual",
             "thread_id": schedule_thread_id,
             "opened_at": time.time(),
+            "keep_open_until_drawdown": bool(keep_open_until_drawdown),
         }
         with self._trade_lock:
             self.paired_trades[trade_id] = entry
@@ -1576,6 +1598,9 @@ class App:
                 min_profit = float(schedule.min_combined_profit if schedule else 0.0 or 0.0)
                 window_start = parse_time_string(schedule.close_window_start) if schedule else None
                 window_end = parse_time_string(schedule.close_window_end) if schedule else None
+                entry_keep_open = bool(info.get("keep_open_until_drawdown"))
+                schedule_keep_open = bool(schedule.keep_open_until_drawdown) if schedule else False
+                keep_open = entry_keep_open or schedule_keep_open
                 profit1 = float(account1.get("last_profit", account1.get("profit", 0.0)) or 0.0)
                 profit2 = float(account2.get("last_profit", account2.get("profit", 0.0)) or 0.0)
                 profits[trade_id] = profit1 + profit2
@@ -1590,6 +1615,7 @@ class App:
                         min_profit,
                         window_start,
                         window_end,
+                        keep_open_until_drawdown=keep_open,
                     )
                 )
         return trades, requests, profits
@@ -1624,6 +1650,8 @@ class App:
         if connected:
             all_threads = [*config.primary_threads, *config.wednesday_threads]
             for schedule in all_threads:
+                if schedule.keep_open_until_drawdown and self._has_active_trade_for_thread(schedule.thread_id):
+                    continue
                 if not schedule_should_trigger(schedule, now, state):
                     continue
                 symbols = [s for s in (schedule.symbol1, schedule.symbol2) if s]

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -132,6 +132,20 @@ class AutomationLogicTests(unittest.TestCase):
             [("T4", "profit")],
         )
 
+    def test_persistent_trade_not_auto_closed(self) -> None:
+        opened = self.now - timedelta(minutes=720)
+        trade = TrackedTrade(
+            "TP",
+            opened,
+            ("EURUSD", "USDJPY"),
+            60,
+            0.4,
+            keep_open_until_drawdown=True,
+        )
+        spreads = {"EURUSD": 0.1, "USDJPY": 0.1}
+        profits = {"TP": 25.0}
+        self.assertEqual(trades_due_for_close([trade], self.now, spreads, profits), [])
+
     def test_gather_active_trades_uses_running_profit(self) -> None:
         schedule = ThreadSchedule(
             thread_id="primary-1",
@@ -141,6 +155,7 @@ class AutomationLogicTests(unittest.TestCase):
             symbol2="USDJPY",
             close_condition="profit",
             min_combined_profit=10.0,
+            keep_open_until_drawdown=True,
         )
         config = AppConfig(
             timezone="UTC",
@@ -178,6 +193,7 @@ class AutomationLogicTests(unittest.TestCase):
         # Combined profit should use the running PnL values only.
         expected_profit = 8.0 + 5.0
         self.assertAlmostEqual(profits["T100"], expected_profit)
+        self.assertTrue(trades[0].keep_open_until_drawdown)
 
     def test_trades_due_for_close_respects_close_window(self) -> None:
         opened = self.now - timedelta(minutes=180)
@@ -222,6 +238,26 @@ class AutomationLogicTests(unittest.TestCase):
             trades_due_for_close([trade], after_window, {"EURUSD": 5.0}, {"T6": 2.0}),
             [("T6", "time_window_elapsed")],
         )
+
+    def test_persistent_schedule_waits_for_existing_trade(self) -> None:
+        schedule = ThreadSchedule(
+            thread_id="primary-1",
+            name="Primary Set 1",
+            enabled=True,
+            entry_start="09:00",
+            entry_end="10:00",
+            weekdays=[0],
+            keep_open_until_drawdown=True,
+        )
+        state = AutomationState(
+            last_runs={},
+            trade_history=[],
+            active_trades=[{"thread_id": "primary-1", "trade_id": "T123"}],
+        )
+        now = datetime(2024, 5, 6, 9, 30, tzinfo=timezone.utc)
+        self.assertFalse(schedule_should_trigger(schedule, now, state))
+        state.active_trades = []
+        self.assertTrue(schedule_should_trigger(schedule, now, state))
 
     def test_drawdown_detection(self) -> None:
         risk = RiskConfig(drawdown_enabled=True, drawdown_stop=5.0)


### PR DESCRIPTION
## Summary
- add a `keep_open_until_drawdown` option to automation schedules and tracked trades
- skip automatic close/re-entry for persistent trades and surface the behaviour in the UI
- document the new flag in the sample configuration and extend automation tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f8d6efdd088325b1b9be758facd56b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `keep_open_until_drawdown` configuration flag to control trade closing behavior.
  * Trades with this flag enabled will skip automatic closing windows and display as "Manual / drawdown."
  * Active trades with this flag prevent new scheduled trades from triggering on the same thread.

* **Tests**
  * Added tests validating drawdown-based trade management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->